### PR TITLE
Don't pollute the global Object namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ require_services 'create_user'
 
 ### $LOAD_PATH helpers
 
-Similarly a "uses" method is available for each component which adds a
+Similarly a "utilizes" method is available for each component which adds a
 directory to the `$LOAD_PATH`. You can then `require` the file as usual:
 
 ```ruby
-spec_uses_models
-spec_uses_presenters
-spec_uses_services
+utilizes_models
+utilizes_presenters
+utilizes_services
 
 require 'user'
 require 'user_presenter'
@@ -70,7 +70,7 @@ require 'create_user'
 Or you can use the one-line version as such:
 
 ```ruby
-spec_uses :models, :presenters, :services
+utilizes :models, :presenters, :services
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helps require files and manage the `$LOAD_PATH` of unit tests which do not boot
 a framework.
 
 For example in Rails if you want fast unit tests you do not boot Rails.
-However this means that "app/models" etc. are not added to the `LOAD_PATH`. 
+However this means that "app/models" etc. are not added to the `LOAD_PATH`.
 This typically means you need to either add the paths or use `require_relative`.
 
 * Explicit requiring of files
@@ -21,7 +21,7 @@ Require only what you need, keep it light and explicit.
 ## Installation
 
 ```ruby
-gem 'spec_requirer', group: :test, github: 'HouseTrip/spec_requirer', tag: 'v0.0.1'
+gem 'spec_requirer', group: :test, github: 'HouseTrip/spec_requirer', tag: 'v0.0.2'
 ```
 
 This is not released to Rubygems yet.
@@ -34,7 +34,7 @@ In your `test_helper` / `spec_helper`:
 require 'pathname'
 require 'spec_requirer'
 
-SpecRequirer.setup(app_root: Pathname(File.dirname(__FILE__)).join('..'),
+SpecRequirer.setup(app_root: File.join(File.dirname(__FILE__), ".."),
                    components: ['models', 'services', 'presenters'])
 ```
 
@@ -58,9 +58,9 @@ Similarly a "uses" method is available for each component which adds a
 directory to the `$LOAD_PATH`. You can then `require` the file as usual:
 
 ```ruby
-uses_models
-uses_presenters
-uses_services
+spec_uses_models
+spec_uses_presenters
+spec_uses_services
 
 require 'user'
 require 'user_presenter'
@@ -70,7 +70,7 @@ require 'create_user'
 Or you can use the one-line version as such:
 
 ```ruby
-uses :models, :presenters, :services
+spec_uses :models, :presenters, :services
 ```
 
 ## Configuration
@@ -89,6 +89,7 @@ SpecRequirer.configure do |config|
 end
 
 SpecRequirer.setup
+include SpecRequirer
 ```
 
 You can also pass some configuration directly to `setup` as such:

--- a/lib/spec_requirer.rb
+++ b/lib/spec_requirer.rb
@@ -5,15 +5,22 @@ require 'spec_requirer/loader'
 module SpecRequirer
   def self.setup(config_options = {})
     config_options.each { |k,v| configuration.send("#{k}=", v) }
-
-    Object.send(:include, Loader.new(configuration))
   end
 
   def self.configuration
     @configuration ||= Configuration.new # TODO: thread-safe...
   end
 
+  def self.loader
+    @loader ||= Loader.new(configuration)
+  end
+
   def self.configure
     yield(configuration)
+  end
+
+  def self.included(receiver)
+    super
+    receiver.send :include, loader
   end
 end

--- a/lib/spec_requirer/configuration.rb
+++ b/lib/spec_requirer/configuration.rb
@@ -6,9 +6,13 @@ module SpecRequirer
 
     attr_accessor :components
 
+    def initialize
+      @components = []
+    end
+
     def clear
       @app_root = nil
-      @components = nil
+      @components = []
     end
 
     def app_root

--- a/lib/spec_requirer/loader.rb
+++ b/lib/spec_requirer/loader.rb
@@ -13,8 +13,8 @@ module SpecRequirer
 
     def define_methods
       @configuration.components.each do |component|
-        define_method "spec_uses_#{component}" do
-          spec_uses(component)
+        define_method "utilizes_#{component}" do
+          utilizes(component)
         end
 
         define_method "require_#{component}" do |*names|
@@ -26,7 +26,7 @@ module SpecRequirer
     end
 
     module Methods
-      def spec_uses(*components)
+      def utilizes(*components)
         components.each do |component|
           add_to_load_path(app_root.join(component.to_s))
         end

--- a/lib/spec_requirer/loader.rb
+++ b/lib/spec_requirer/loader.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module SpecRequirer
   class Loader < Module
 

--- a/lib/spec_requirer/loader.rb
+++ b/lib/spec_requirer/loader.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module SpecRequirer
   class Loader < Module
 
@@ -6,15 +8,15 @@ module SpecRequirer
       define_methods
     end
 
-    def included(descendant)
+    def included(receiver)
       super
-      descendant.class_eval { include Methods }
+      receiver.send :include, Methods
     end
 
     def define_methods
       @configuration.components.each do |component|
-        define_method "uses_#{component}" do
-          uses(component)
+        define_method "spec_uses_#{component}" do
+          spec_uses(component)
         end
 
         define_method "require_#{component}" do |*names|
@@ -26,7 +28,7 @@ module SpecRequirer
     end
 
     module Methods
-      def uses(*components)
+      def spec_uses(*components)
         components.each do |component|
           add_to_load_path(app_root.join(component.to_s))
         end

--- a/lib/spec_requirer/version.rb
+++ b/lib/spec_requirer/version.rb
@@ -1,3 +1,3 @@
 module SpecRequirer
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/spec_requirer/loader_spec.rb
+++ b/spec/spec_requirer/loader_spec.rb
@@ -13,9 +13,9 @@ describe SpecRequirer::Loader do
   describe "extended" do
     before { subject.extend(SpecRequirer::Loader.new(configuration))  }
 
-    it 'creates spec_uses_* methods for each component in configuration' do
+    it 'creates utilizes_* methods for each component in configuration' do
       components.each do |component|
-        expect(subject).to respond_to "spec_uses_#{component}"
+        expect(subject).to respond_to "utilizes_#{component}"
       end
     end
 
@@ -31,8 +31,8 @@ describe SpecRequirer::Loader do
 
     before { subject.include(SpecRequirer::Loader.new(configuration)) }
 
-    it 'creates a uses method' do
-      expect(class_under_test).to respond_to(:spec_uses)
+    it 'creates a utilizes method' do
+      expect(class_under_test).to respond_to(:utilizes)
     end
   end
 end

--- a/spec/spec_requirer/loader_spec.rb
+++ b/spec/spec_requirer/loader_spec.rb
@@ -1,22 +1,38 @@
 describe SpecRequirer::Loader do
   let(:app_root)      { Pathname(File.dirname(__FILE__)) }
   let(:components)    { ['models', 'presenters'] }
-  let(:configuration) { double('configuration', components: components,
-                                                app_root:   app_root) }
+  let(:configuration) do
+    double('configuration',
+        components:   components,
+        app_root:     app_root
+    )
+  end
 
   subject { Class.new }
 
-  before { subject.extend(SpecRequirer::Loader.new(configuration))  }
+  describe "extended" do
+    before { subject.extend(SpecRequirer::Loader.new(configuration))  }
 
-  it 'creates uses_* methods for each component in configuration' do
-    components.each do |component|
-      expect(subject).to respond_to "uses_#{component}"
+    it 'creates spec_uses_* methods for each component in configuration' do
+      components.each do |component|
+        expect(subject).to respond_to "spec_uses_#{component}"
+      end
+    end
+
+    it 'creates require_* methods for each component in configuration' do
+      components.each do |component|
+        expect(subject).to respond_to "require_#{component}"
+      end
     end
   end
 
-  it 'creates require_* methods for each component in configuration' do
-    components.each do |component|
-      expect(subject).to respond_to "require_#{component}"
+  describe "included" do
+    let(:class_under_test) { subject.new }
+
+    before { subject.include(SpecRequirer::Loader.new(configuration)) }
+
+    it 'creates a uses method' do
+      expect(class_under_test).to respond_to(:spec_uses)
     end
   end
 end

--- a/spec/spec_requirer_spec.rb
+++ b/spec/spec_requirer_spec.rb
@@ -22,7 +22,7 @@ describe SpecRequirer do
 
     describe '#uses_models' do
       it 'adds models path to LOAD_PATH' do
-        class_under_test.spec_uses_models
+        class_under_test.utilizes_models
         expect($LOAD_PATH).to include app_root.join('models').to_s
       end
     end
@@ -37,7 +37,7 @@ describe SpecRequirer do
 
     describe '#uses' do
       it 'adds given components to LOAD_PATH' do
-        class_under_test.spec_uses :models, :presenters
+        class_under_test.utilizes :models, :presenters
         expect($LOAD_PATH).to include app_root.join('models').to_s
         expect($LOAD_PATH).to include app_root.join('presenters').to_s
       end

--- a/spec/spec_requirer_spec.rb
+++ b/spec/spec_requirer_spec.rb
@@ -1,57 +1,46 @@
 describe SpecRequirer do
+
   let(:app_root) { Pathname(File.dirname(__FILE__)).join('app') }
 
-  describe '#setup' do
-    before { subject.setup(components: ['models']) }
-
-    it 'adds Object#uses_models' do
-      expect(Object).to respond_to :uses_models
-    end
-
-    it 'adds Object#require_model' do
-      expect(Object).to respond_to :require_models
-    end
-
-    it 'does not break Object#respond_to' do
-      expect(Object).to respond_to :object_id
+  describe 'setup options' do
+    it 'accepts configurion' do
+      SpecRequirer.setup(app_root: '/foo', components: ['foo'])
+      expect(SpecRequirer.configuration.app_root.to_s).to eq '/foo'
+      expect(SpecRequirer.configuration.components).to eq ['foo']
     end
   end
 
-  describe '#setup options' do
-    it 'accepts configuration' do
-      subject.setup(app_root: '/foo', components: ['foo'])
-      expect(subject.configuration.app_root.to_s).to eq '/foo'
-      expect(subject.configuration.components).to eq ['foo']
+  context "included methods" do
+    let(:class_under_test) { ClassUnderTest.new }
+
+    before do
+      SpecRequirer.setup(app_root: app_root, components: ['models'])
+      class ClassUnderTest
+        include SpecRequirer
+      end
     end
-  end
 
-  describe '#uses_models' do
-    before { subject.setup(app_root: app_root, components: ['models']) }
-
-    it 'adds models path to LOAD_PATH' do
-      uses_models
-      expect($LOAD_PATH).to include app_root.join('models').to_s
+    describe '#uses_models' do
+      it 'adds models path to LOAD_PATH' do
+        class_under_test.spec_uses_models
+        expect($LOAD_PATH).to include app_root.join('models').to_s
+      end
     end
-  end
 
-  describe '#require_model' do
-    before { subject.setup(app_root: app_root, components: ['models']) }
-
-    it 'requires a model file' do
-      expect { require_models(:user, :award) }.to_not raise_error
-      expect { User.new }.to_not raise_error
-      expect { Award.new }.to_not raise_error
+    describe '#require_model' do
+      it 'requires a model file' do
+        expect { class_under_test.require_models(:user, :award) }.to_not raise_error
+        expect { User.new }.to_not raise_error
+        expect { Award.new }.to_not raise_error
+      end
     end
-  end
 
-
-  describe '#uses' do
-    before { subject.setup(app_root: app_root, components: ['models']) }
-
-    it 'adds given components to LOAD_PATH' do
-      uses :models, :presenters
-      expect($LOAD_PATH).to include app_root.join('models').to_s
-      expect($LOAD_PATH).to include app_root.join('presenters').to_s
+    describe '#uses' do
+      it 'adds given components to LOAD_PATH' do
+        class_under_test.spec_uses :models, :presenters
+        expect($LOAD_PATH).to include app_root.join('models').to_s
+        expect($LOAD_PATH).to include app_root.join('presenters').to_s
+      end
     end
   end
 end


### PR DESCRIPTION
:see_no_evil: Remove the monkeypatch on Object so we don't polluate the global Object namespace
:twisted_rightwards_arrows: Renames `uses` to far less generic `spec_uses` to avoid conflicts with any  `uses` method in code that uses SpecRequirer
:twisted_rightwards_arrows: Also renames `uses_models` etc. to `spec_uses_models` for consistency
:memo: Configuration is now slightly different, README is updated to reflect the need to `include SpecRequirer` as well as calling `.setup`

I've tested this with HouseBot and it appears to work well. 
